### PR TITLE
Remove android:networkSecurityConfig

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,6 @@
         android:allowBackup="true"
         android:icon="@drawable/logo"
         android:label="@string/app_name"
-        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@drawable/logo"
         android:supportsRtl="true"
         android:usesCleartextTraffic="true"


### PR DESCRIPTION
Currently, the ```DApp``` of the HTTP protocol is still not supported in WebView.

Although ```android:usesCleartextTraffic="true"``` has been added, ```android:networkSecurityConfig``` has a higher priority, so if WebView needs to support HTTP protocol,  need to remove ```android:networkSecurityConfig```.